### PR TITLE
feat: switch skip-branch-protections to bypass-branch-protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,14 @@ permissions:
 
 ## Options
 
-| Key                       | Type      | Default                                       | Description                                                                             |
-| ------------------------- | --------- | --------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `branch`                  | `string`  | `"main"`                                      | Branch to delete and recreate branch protections on (unless `skip-branch-protections`). |
-| `git-user-email`          | `string`  | `${<git-user-name>}@users.noreply.github.com` | `git config user.email` value for Git commits.                                          |
-| `git-user-name`           | `string`  | `${github.context.actor}`                     | `git config user.name` value for Git commits.                                           |
-| `github-token`            | `string`  | `${GITHUB_TOKEN}`                             | GitHub token (PAT) with _repo_ and _workflow_ permissions.                              |
-| `npm-token`               | `string`  | `${NPM_TOKEN}`                                | npm access token with the _automation_ role.                                            |
-| `skip-branch-protections` | `boolean` | `false`                                       | Whether to skip deleting and recreating branch protections.                             |
-| `release-it-args`         | `string`  | `""`                                          | Any arbitrary arguments to pass to `npx release-it --verbose`.                          |
+| Key                         | Type     | Default                                       | Description                                                    |
+| --------------------------- | -------- | --------------------------------------------- | -------------------------------------------------------------- |
+| `bypass-branch-protections` | `string` | _(none)_                                      | A branch delete and recreate branch protections on.            |
+| `git-user-email`            | `string` | `${<git-user-name>}@users.noreply.github.com` | `git config user.email` value for Git commits.                 |
+| `git-user-name`             | `string` | `${github.context.actor}`                     | `git config user.name` value for Git commits.                  |
+| `github-token`              | `string` | `${GITHUB_TOKEN}`                             | GitHub token (PAT) with _repo_ and _workflow_ permissions.     |
+| `npm-token`                 | `string` | `${NPM_TOKEN}`                                | npm access token with the _automation_ role.                   |
+| `release-it-args`           | `string` | `""`                                          | Any arbitrary arguments to pass to `npx release-it --verbose`. |
 
 ### Node API
 
@@ -103,7 +102,16 @@ Note that all non-`boolean` inputs are required and do not have default values i
 `release-it-action` needs to run on the latest commit on the default/release branch and with a [concurrency group](https://docs.github.com/en/actions/using-jobs/using-concurrency).
 Otherwise, if multiple workflows are triggered quickly, later workflows might not include release commits from earlier workflows.
 
-### Why does this delete and recreate branch protections?
+### Why is there an option to bypass branch protections?
+
+**The `bypass-branch-protections` option is not recommended.**
+
+Some repositories have strict legacy branch protections which make it difficult to automate tasks that require pushing to the `main` branch.
+Bypassing those branch protections can make it easier to configure `release-it` to create Git commits.
+
+It's recommended to instead use GitHub's newer and more granular [repository rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets).
+
+#### Why does the option delete and recreate branch protections?
 
 It would be great to instead either change which branch is protected or have a native GitHub API to disable a branch protection rule.
 Neither exist at time of writing.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ permissions:
 
 | Key                         | Type     | Default                                       | Description                                                    |
 | --------------------------- | -------- | --------------------------------------------- | -------------------------------------------------------------- |
-| `bypass-branch-protections` | `string` | _(none)_                                      | A branch delete and recreate branch protections on.            |
+| `bypass-branch-protections` | `string` | _(none)_                                      | A branch to delete and recreate branch protections on.         |
 | `git-user-email`            | `string` | `${<git-user-name>}@users.noreply.github.com` | `git config user.email` value for Git commits.                 |
 | `git-user-name`             | `string` | `${github.context.actor}`                     | `git config user.name` value for Git commits.                  |
 | `github-token`              | `string` | `${GITHUB_TOKEN}`                             | GitHub token (PAT) with _repo_ and _workflow_ permissions.     |

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 author: JoshuaKGoldberg
 description: Runs release-it as a GitHub Action, with handling for semantic releases and protected branches. 📤
 inputs:
-  branch:
-    description: Branch to delete and recreate branch protections on (unless `skip-branch-protections`).
+  bypass-branch-protections:
+    description: Branch to delete and recreate branch protections on.
   git-user-email:
     description: "`git config user.email` value for Git commits."
   git-user-name:
@@ -11,9 +11,6 @@ inputs:
     description: GitHub token (PAT) with repo and workflow permissions.
   npm-token:
     description: npm access token with the automation role.
-  skip-branch-protections:
-    default: "false"
-    description: Whether to skip deleting and recreating branch protections.
   release-it-args:
     description: Any arbitrary arguments to pass to `npx release-it --verbose`.
 name: release-it Action

--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,7 @@
 		"npmpackagejsonlintrc",
 		"outro",
 		"packagejson",
+		"rulesets",
 		"tseslint"
 	]
 }

--- a/src/action/runReleaseItAction.test.ts
+++ b/src/action/runReleaseItAction.test.ts
@@ -46,7 +46,7 @@ describe("runReleaseItAction", () => {
 			[
 			  [
 			    {
-			      "branch": "main",
+			      "bypassBranchProtections": undefined,
 			      "gitUserEmail": "undefined@users.noreply.github.com",
 			      "gitUserName": undefined,
 			      "githubToken": "mock-github-token",
@@ -54,7 +54,6 @@ describe("runReleaseItAction", () => {
 			      "owner": "context-owner",
 			      "releaseItArgs": undefined,
 			      "repo": "context-repo",
-			      "skipBranchProtections": false,
 			    },
 			  ],
 			]
@@ -70,7 +69,7 @@ describe("runReleaseItAction", () => {
 			[
 			  [
 			    {
-			      "branch": "mock-branch",
+			      "bypassBranchProtections": "mock-bypass-branch-protections",
 			      "gitUserEmail": "mock-git-user-email",
 			      "gitUserName": "mock-git-user-name",
 			      "githubToken": "mock-github-token",
@@ -78,7 +77,6 @@ describe("runReleaseItAction", () => {
 			      "owner": "context-owner",
 			      "releaseItArgs": "mock-release-it-args",
 			      "repo": "context-repo",
-			      "skipBranchProtections": false,
 			    },
 			  ],
 			]

--- a/src/action/runReleaseItAction.ts
+++ b/src/action/runReleaseItAction.ts
@@ -8,7 +8,7 @@ export async function runReleaseItAction(context: typeof github.context) {
 	const gitUserName = core.getInput("git-user-name") || context.actor;
 
 	await releaseItAction({
-		branch: core.getInput("branch") || "main",
+		bypassBranchProtections: core.getInput("bypass-branch-protections"),
 		githubToken: getTokenInput("github-token", "GITHUB_TOKEN"),
 		gitUserEmail:
 			core.getInput("git-user-email") ||
@@ -18,6 +18,5 @@ export async function runReleaseItAction(context: typeof github.context) {
 		owner: context.repo.owner,
 		releaseItArgs: core.getInput("release-it-args"),
 		repo: context.repo.repo,
-		skipBranchProtections: core.getBooleanInput("skip-branch-protections"),
 	});
 }

--- a/src/runBypassingBranchProtections.test.ts
+++ b/src/runBypassingBranchProtections.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { runBypassingBranchProtections } from "./runBypassingBranchProtections.js";
+import { Octokit } from "./types.js";
+
+const mockRequest = vi.fn();
+const mockOctokit = { request: mockRequest } as unknown as Octokit;
+
+const mockFetchProtections = vi.fn();
+
+vi.mock("./steps/fetchProtections.js", () => ({
+	get fetchProtections() {
+		return mockFetchProtections;
+	},
+}));
+
+const mockDeleteProtections = vi.fn();
+
+vi.mock("./steps/deleteProtections.js", () => ({
+	get deleteProtections() {
+		return mockDeleteProtections;
+	},
+}));
+
+const mockRecreateProtections = vi.fn();
+
+vi.mock("./steps/recreateProtections.js", () => ({
+	get recreateProtections() {
+		return mockRecreateProtections;
+	},
+}));
+
+describe("runBypassingBranchProtections", () => {
+	test("API calls", async () => {
+		const run = vi.fn();
+
+		await runBypassingBranchProtections(
+			{
+				branch: "",
+				owner: "",
+				repo: "",
+			},
+			mockOctokit,
+			run,
+		);
+
+		expect(mockFetchProtections.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "octokit": {
+			        "request": [MockFunction spy],
+			      },
+			      "requestData": {
+			        "branch": "",
+			        "headers": {
+			          "X-GitHub-Api-Version": "2022-11-28",
+			        },
+			        "owner": "",
+			        "repo": "",
+			      },
+			    },
+			  ],
+			]
+		`);
+		expect(mockDeleteProtections.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "existingProtections": undefined,
+			      "octokit": {
+			        "request": [MockFunction spy],
+			      },
+			      "requestData": {
+			        "branch": "",
+			        "headers": {
+			          "X-GitHub-Api-Version": "2022-11-28",
+			        },
+			        "owner": "",
+			        "repo": "",
+			      },
+			    },
+			  ],
+			]
+		`);
+		expect(mockRecreateProtections.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "commonRequestData": {
+			        "branch": "",
+			        "headers": {
+			          "X-GitHub-Api-Version": "2022-11-28",
+			        },
+			        "owner": "",
+			        "repo": "",
+			      },
+			      "existingProtections": undefined,
+			      "octokit": {
+			        "request": [MockFunction spy],
+			      },
+			    },
+			  ],
+			]
+		`);
+		expect(run).toHaveBeenCalled();
+	});
+});

--- a/src/runBypassingBranchProtections.ts
+++ b/src/runBypassingBranchProtections.ts
@@ -1,0 +1,42 @@
+import { deleteProtections } from "./steps/deleteProtections.js";
+import { fetchProtections } from "./steps/fetchProtections.js";
+import { recreateProtections } from "./steps/recreateProtections.js";
+import { Octokit } from "./types.js";
+
+export interface CommonData {
+	branch: string;
+	owner: string;
+	repo: string;
+}
+
+export async function runBypassingBranchProtections(
+	commonData: CommonData,
+	octokit: Octokit,
+	run: () => Promise<void>,
+) {
+	const commonRequestData = {
+		...commonData,
+		headers: {
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+	};
+
+	const existingProtections = await fetchProtections({
+		octokit,
+		requestData: commonRequestData,
+	});
+
+	await deleteProtections({
+		existingProtections,
+		octokit,
+		requestData: commonRequestData,
+	});
+
+	await run();
+
+	await recreateProtections({
+		commonRequestData,
+		existingProtections,
+		octokit,
+	});
+}

--- a/src/steps/deleteProtections.test.ts
+++ b/src/steps/deleteProtections.test.ts
@@ -25,7 +25,6 @@ const requestData = { branch, owner: "test-owner", repo: "test-repo" };
 describe("deleteProtections", () => {
 	it("deletes protections when existingProtections exists", async () => {
 		await deleteProtections({
-			branch: "",
 			existingProtections: {},
 			octokit: mockOctokit,
 			requestData,
@@ -48,7 +47,6 @@ describe("deleteProtections", () => {
 
 	it("does not delete protections when existingProjections does not exist", async () => {
 		await deleteProtections({
-			branch: "",
 			existingProtections: undefined,
 			octokit: mockOctokit,
 			requestData,
@@ -57,7 +55,7 @@ describe("deleteProtections", () => {
 		expect(mockInfo.mock.calls).toMatchInlineSnapshot(`
 			[
 			  [
-			    "No existing branch protections found for .",
+			    "No existing branch protections found for test-branch.",
 			  ],
 			]
 		`);

--- a/src/steps/deleteProtections.ts
+++ b/src/steps/deleteProtections.ts
@@ -6,21 +6,19 @@ import { tryCatchInfoAction } from "../tryCatchInfoAction.js";
 import { Octokit } from "../types.js";
 
 export interface DeleteProtectionsOptions {
-	branch: string;
 	existingProtections: object | undefined;
 	octokit: Octokit;
 	requestData: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"];
 }
 
 export async function deleteProtections({
-	branch,
 	existingProtections,
 	octokit,
 	requestData,
 }: DeleteProtectionsOptions) {
 	if (existingProtections) {
 		await tryCatchInfoAction(
-			`deleting existing protections for ${branch}`,
+			`deleting existing protections for ${requestData.branch}`,
 			async () =>
 				await octokit.request(
 					`DELETE /repos/{owner}/{repo}/branches/{branch}/protection`,
@@ -28,6 +26,8 @@ export async function deleteProtections({
 				),
 		);
 	} else {
-		core.info(`No existing branch protections found for ${branch}.`);
+		core.info(
+			`No existing branch protections found for ${requestData.branch}.`,
+		);
 	}
 }

--- a/src/steps/fetchProtections.test.ts
+++ b/src/steps/fetchProtections.test.ts
@@ -16,25 +16,12 @@ const mockOctokit = { request: mockRequest } as unknown as Octokit;
 const requestData = { branch, owner: "test-owner", repo: "test-repo" };
 
 describe("fetchProtections", () => {
-	it("returns protections when skipBranchProtections is false", async () => {
+	it("returns protections", async () => {
 		const actual = await fetchProtections({
-			branch: "",
 			octokit: mockOctokit,
 			requestData,
-			skipBranchProtections: false,
 		});
 
 		expect(actual).toBe(mockProtections);
-	});
-
-	it("does not return protections when skipBranchProtections is true", async () => {
-		const actual = await fetchProtections({
-			branch: "",
-			octokit: mockOctokit,
-			requestData,
-			skipBranchProtections: true,
-		});
-
-		expect(actual).toBeUndefined();
 	});
 });

--- a/src/steps/fetchProtections.ts
+++ b/src/steps/fetchProtections.ts
@@ -4,26 +4,20 @@ import { tryCatchInfoAction } from "../tryCatchInfoAction.js";
 import { ExistingProtections, Octokit } from "../types.js";
 
 export interface FetchProtectionsOptions {
-	branch: string;
 	octokit: Octokit;
 	requestData: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"];
-	skipBranchProtections: boolean | undefined;
 }
 
 export async function fetchProtections({
-	branch,
 	octokit,
 	requestData,
-	skipBranchProtections,
 }: FetchProtectionsOptions): Promise<ExistingProtections | undefined> {
-	return skipBranchProtections
-		? undefined
-		: await tryCatchInfoAction(
-				`fetching existing branch protections for ${branch}`,
-				async () =>
-					await octokit.request(
-						"GET /repos/{owner}/{repo}/branches/{branch}/protection",
-						requestData,
-					),
-		  );
+	return await tryCatchInfoAction(
+		`fetching existing branch protections for ${requestData.branch}`,
+		async () =>
+			await octokit.request(
+				"GET /repos/{owner}/{repo}/branches/{branch}/protection",
+				requestData,
+			),
+	);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #403
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/release-it-action/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/release-it-action/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Renames the option from `skip-branch-protections` to `bypass-branch-protections`. This means the deletion & recreation of branch protections is now off by default. Adds a note to the README.md explaining why.

Not strictly necessary, but brain-pleasing: I also refactored a `runBypassingBranchProtections` function out of `index.ts`'s `releaseItAction` function. This separated the high-level running concerns from branch protection concerns, and made the former easier to unit test.

💖 